### PR TITLE
Fix commands for using a local LLM

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "tsc",
     "dev": "tsx src/cli.ts",
     "prepublishOnly": "npm run build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "test:ollama": "git-rewrite-commits --provider ollama"
   },
   "keywords": [
     "git",

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,6 +1,16 @@
 import fetch from 'node-fetch';
 import { AIProvider } from './types';
 
+interface OllamaChatResponse {
+  message?: {
+    content?: string;
+  };
+}
+
+interface OllamaTagsResponse {
+  models?: { name: string }[];
+}
+
 export class OllamaProvider implements AIProvider {
   private baseUrl: string;
   private model: string;
@@ -47,7 +57,7 @@ export class OllamaProvider implements AIProvider {
         throw new Error(`Ollama API error (${response.status}): ${errorText}`);
       }
 
-      const data = await response.json();
+      const data = await response.json() as OllamaChatResponse;
       const message = data.message?.content?.trim();
       
       if (!message) {
@@ -73,7 +83,7 @@ export class OllamaProvider implements AIProvider {
         throw new Error('Ollama server is not responding correctly');
       }
 
-      const data = await response.json();
+      const data = await response.json() as OllamaTagsResponse;
       const models = data.models || [];
       const modelNames = models.map((m: any) => m.name.split(':')[0]);
       


### PR DESCRIPTION
According to #1, using the `--provider` flag does not work when specifying Ollama. This PR fixes the Ollama implementation, while keeping compatibility with external AI providers like OpenAI.