### PR TITLE
feat: add Google Gemini provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 # OpenAI API Key
 # Get yours at: https://platform.openai.com/api-keys
 OPENAI_API_KEY=sk-your-api-key-here
+
+# Gemini API Key
+# Get yours at: https://aistudio.google.com/u/1/api-keys
+GEMINI_API_KEY=gemini-api-key

--- a/package.json
+++ b/package.json
@@ -47,16 +47,17 @@
     "LICENSE"
   ],
   "dependencies": {
-    "openai": "^4.20.0",
-    "commander": "^11.1.0",
+    "@google/generative-ai": "^0.24.1",
     "chalk": "^5.3.0",
-    "ora": "^7.0.1",
-    "node-fetch": "^3.3.2"
+    "commander": "^11.1.0",
+    "node-fetch": "^3.3.2",
+    "openai": "^4.20.0",
+    "ora": "^7.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",
-    "typescript": "^5.3.2",
-    "tsx": "^4.6.2"
+    "tsx": "^4.6.2",
+    "typescript": "^5.3.2"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@google/generative-ai':
+        specifier: ^0.24.1
+        version: 0.24.1
       chalk:
         specifier: ^5.3.0
         version: 5.6.2
@@ -191,6 +194,10 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@google/generative-ai@0.24.1':
+    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
+    engines: {node: '>=18.0.0'}
 
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
@@ -571,6 +578,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.12':
     optional: true
+
+  '@google/generative-ai@0.24.1': {}
 
   '@types/node-fetch@2.6.13':
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import ora from 'ora';
 import { AIProvider, createProvider } from './providers/index.js';
 
 export interface RewriteOptions {
-  provider?: 'openai' | 'ollama' | 'claude-code';
+  provider?: 'openai' | 'ollama' | 'claude-code' | 'gemini';
   apiKey?: string;
   model?: string;
   ollamaUrl?: string;
@@ -41,6 +41,7 @@ export class GitCommitRewriter {
     const model = options.model || (
       provider === 'ollama' ? 'llama3.2' :
       provider === 'claude-code' ? 'haiku' :
+      provider === 'gemini' ? 'gemini-2.5-flash-lite' :
       'gpt-3.5-turbo'
     );
     
@@ -74,7 +75,7 @@ export class GitCommitRewriter {
 
   private execCommand(command: string): string {
     try {
-      return execSync(command, { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 });
+      return execSync(command, { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] });
     } catch (error: any) {
       throw new Error(`Command failed: ${command}\n${error.message}`);
     }

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -1,0 +1,39 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { AIProvider } from './types.js';
+
+export class GeminiProvider implements AIProvider {
+  private genAI: GoogleGenerativeAI;
+  private model: string;
+
+  constructor(apiKey: string, model: string = 'gemini-2.5-flash-lite') {
+    if (!apiKey) {
+      throw new Error('Gemini API key is required');
+    }
+    this.genAI = new GoogleGenerativeAI(apiKey);
+    this.model = model;
+  }
+
+  async generateCommitMessage(prompt: string, systemPrompt: string): Promise<string> {
+    const generativeModel = this.genAI.getGenerativeModel({
+      model: this.model,
+      systemInstruction: systemPrompt,
+      generationConfig: {
+        temperature: 0.3,
+        maxOutputTokens: 200,
+      },
+    });
+
+    const result = await generativeModel.generateContent(prompt);
+    const message = result.response.text().trim();
+
+    if (!message) {
+      throw new Error('No commit message generated');
+    }
+
+    return message;
+  }
+
+  getName(): string {
+    return `Gemini (${this.model})`;
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,11 +2,13 @@ import { AIProvider, ProviderOptions } from './types.js';
 import { OpenAIProvider } from './openai.js';
 import { OllamaProvider } from './ollama.js';
 import { ClaudeCodeProvider } from './claude-code.js';
+import { GeminiProvider } from './gemini.js';
 
 export { AIProvider } from './types.js';
 export { OpenAIProvider } from './openai.js';
 export { OllamaProvider } from './ollama.js';
 export { ClaudeCodeProvider } from './claude-code.js';
+export { GeminiProvider } from './gemini.js';
 
 export function createProvider(options: ProviderOptions): AIProvider {
   const providerType = options.provider || 'openai';
@@ -15,6 +17,12 @@ export function createProvider(options: ProviderOptions): AIProvider {
     return new OllamaProvider(options.model || 'llama3.2', options.ollamaUrl);
   } else if (providerType === 'claude-code') {
     return new ClaudeCodeProvider(options.model || 'haiku');
+  } else if (providerType === 'gemini') {
+    const apiKey = options.apiKey || process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      throw new Error('Gemini API key is required. Set GEMINI_API_KEY environment variable or pass it as an option.');
+    }
+    return new GeminiProvider(apiKey, options.model || 'gemini-2.5-flash-lite');
   } else {
     const apiKey = options.apiKey || process.env.OPENAI_API_KEY;
     if (!apiKey) {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -4,7 +4,7 @@ export interface AIProvider {
 }
 
 export interface ProviderOptions {
-  provider?: 'openai' | 'ollama' | 'claude-code';
+  provider?: 'openai' | 'ollama' | 'claude-code' | 'gemini';
   apiKey?: string;
   model?: string;
   ollamaUrl?: string;


### PR DESCRIPTION
## What

Adds Google Gemini as a fourth AI provider alongside OpenAI, Ollama, and
Claude Code. Default model is `gemini-2.5-flash-lite`.

## Changes

**New provider**
- `src/providers/gemini.ts` — `GeminiProvider` using `@google/generative-ai`
  with `temperature: 0.3` and `maxOutputTokens: 200`

**Wiring**
- `src/providers/types.ts` — added `'gemini'` to `ProviderOptions.provider`
  union type
- `src/providers/index.ts` — factory routes to `GeminiProvider`, reads
  `GEMINI_API_KEY` env var
- `src/index.ts` — added `'gemini'` to `RewriteOptions.provider` union type,
  added `gemini-2.5-flash-lite` to default model resolution chain, fixed
  `execCommand` to use `stdio: ['pipe', 'pipe', 'pipe']`

**CLI**
- `src/cli.ts` — updated `--provider` description, `--api-key` description,
  `--model` description; added Gemini API key validation error, informational
  message, help text, and usage examples

**Other**
- `.env.example` — added `GEMINI_API_KEY` entry
- `package.json` — added `@google/generative-ai ^0.24.1` dependency

## Usage

```bash
export GEMINI_API_KEY="your-api-key"
git-rewrite-commits --provider gemini

# or with a specific model
git-rewrite-commits --provider gemini --model gemini-2.5-flash-lite
